### PR TITLE
Add -dev versions of static libs

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -16,10 +16,13 @@ RUN set -eu && \
     gcompat \
     linux-headers \
     lz4-static \
+    lz4-dev \
     musl-dev \
     perl \
     snappy-static \
-    zlib-static 
+    snappy-dev \
+    zlib-static \
+    zlib-dev
 
 COPY ./bin/install-mimalloc ./bin/install-wasmvm ./bin/install-rocksdb /usr/local/bin/
 


### PR DESCRIPTION
When testing kava build rocksdb was built but without compression library (like lz4) support, apparently `-dev` packages are needed also which contain header files to build rocksdb with lz4 and other compressions.

@gregnuj 